### PR TITLE
feat: Perform less json parsing/stringifying + reduce GC

### DIFF
--- a/packages/explorerkit-server/src/components/idls.ts
+++ b/packages/explorerkit-server/src/components/idls.ts
@@ -55,7 +55,7 @@ export async function loadAllIdls(programIds: string[]): Promise<IdlsMap> {
         idls.set(programId, cachedIdl && new SolanaFMParser(cachedIdl.idl, programId));
       }
 
-      if (cachedIdl.expiresAt.getTime() < Date.now()) {
+      if (new Date(cachedIdl.expiresAt).getTime() < Date.now()) {
         addIdlToRefreshQueue(programId);
       }
     })
@@ -64,7 +64,9 @@ export async function loadAllIdls(programIds: string[]): Promise<IdlsMap> {
   return idls;
 }
 
-export type MaybeIdl = { type: "MISSING"; expiresAt: Date } | { type: "IDL"; idl: IdlItem; expiresAt: Date };
+export type MaybeIdl =
+  | { type: "MISSING"; expiresAt: number | string }
+  | { type: "IDL"; idl: IdlItem; expiresAt: number | string };
 
 const idlRefreshQueue = new Set<string>();
 
@@ -144,5 +146,7 @@ export function initIdlsRefreshBackgroundJob(idlRefreshIntervalMs: number) {
 }
 
 const intoMaybeIdl = (idl: IdlItem | null, expiresAt: Date): MaybeIdl => {
-  return idl === null ? { type: "MISSING", expiresAt } : { type: "IDL", idl, expiresAt };
+  return idl === null
+    ? { type: "MISSING", expiresAt: expiresAt.getTime() }
+    : { type: "IDL", idl, expiresAt: expiresAt.getTime() };
 };

--- a/packages/explorerkit-server/src/core/shared-dependencies.ts
+++ b/packages/explorerkit-server/src/core/shared-dependencies.ts
@@ -1,13 +1,14 @@
+import { MaybeIdl } from "@/components/idls";
 import { createCache } from "@/core/cache";
 
 type SharedDependencies = {
-  cache: Awaited<ReturnType<typeof createCache>>;
+  cache: Awaited<ReturnType<typeof createCache<MaybeIdl>>>;
 };
 
 let sharedDependencies: SharedDependencies | null = null;
 
 export async function initSharedDependencies(): Promise<SharedDependencies> {
-  const cache = await createCache();
+  const cache = await createCache<MaybeIdl>();
 
   sharedDependencies = {
     cache,

--- a/packages/explorerkit-server/src/index.ts
+++ b/packages/explorerkit-server/src/index.ts
@@ -8,7 +8,7 @@ async function main() {
     await initSharedDependencies();
     initIdlsRefreshBackgroundJob(config.IDL_REFRESH_INTERVAL_MS);
 
-    await app.listen({ port: config.PORT });
+    await app.listen({ port: config.PORT, host: "0.0.0.0" });
     app.log.info(`Server started on port ${config.PORT}`);
   } catch (err) {
     app.log.error(err);


### PR DESCRIPTION
At the moment explorer-kit is solely CPU throttled.

This PR aims to reduce json parsing/stringyfying and also reduce memory waste by caching whole IDL objects in LRU cache instead of stringifying IDL representation there. LRU cache has 99%+ hit rate therefore this should provide a pretty big improvement. 
Locally this has ~40% improvement over previous implementation